### PR TITLE
Fix PyPI publishing action

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -134,7 +134,7 @@ jobs:
           s3pypi --bucket hyp3-pypi --force --verbose
 
       - name: Upload to PyPI.org
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__


### PR DESCRIPTION
We didn't publish to PyPI.org last release because of an errant `master` that should be a `main`