### PR TITLE
Add processor to name convention

### DIFF
--- a/hyp3_metadata/readme.md.txt.j2
+++ b/hyp3_metadata/readme.md.txt.j2
@@ -7,7 +7,7 @@ Processing Date/Time: {{ processing_date.isoformat(timespec='seconds') }}
 
 The folder and each of its contents all share the same base name, using the following convention:
 ```
-S1x_yy_aaaaaaaaTbbbbbb_ppo_RTCzz_G_defklm_ssss
+S1x_yy_aaaaaaaaTbbbbbb_ppo_RTCzz_u_defklm_ssss
 x:          Sentinel-1 Mission (A or B)
 yy:         Beam Mode
 aaaaaaaa:   Start Date of Acquisition (YYYYMMDD)
@@ -15,6 +15,7 @@ bbbbbb:     Start Time of Acquisition (HHMMSS)
 pp:         Polarization
 o:          Orbit Type: Precise (P), Restituted (R), or Original Predicted (O)
 zz:         Terrain Correction Resolution
+u:          Software Package Used: GAMMA (G)
 d:          Gamma-0 (g) or Sigma-0 (s) Output
 e:          Power (p) or Amplitude (a) Output
 f:          Unmasked (u) or Water Masked (w)


### PR DESCRIPTION
Change the G to a u in the filename scheme, and add a descriptor for the processor used.