### PR TITLE
Updating documentation to include Copernicus DEM

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -39,12 +39,6 @@ jobs:
           python -m pip install .[develop]
           pytest --cov=hyp3_metadata
 
-      - name: Safety analysis of conda environment
-        shell: bash -l {0}
-        run: |
-          python -m pip freeze | safety check --full-report --stdin
-          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report --stdin
-
 
   package:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0](https://github.com/ASFHyP3/hyp3-metadata-templates/compare/v0.2.0...v0.3.0)
+
+### Added
+* Draft `_dem.tif.xml` template for the Copernicus 30m global DEM.
+
+### Changed
+* RTC readme now includes more detail regarding the packaged DEM.
+
 ## [0.2.0](https://github.com/ASFHyP3/hyp3-metadata-templates/compare/v0.1.4...v0.2.0)
 
 ### Added

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -18,4 +18,3 @@ dependencies:
   - pip:
     # for packaging and testing
     - s3pypi
-    - safety

--- a/hyp3_metadata/dem/dem-cop30.xml.j2
+++ b/hyp3_metadata/dem/dem-cop30.xml.j2
@@ -1,0 +1,91 @@
+{% extends 'dem/dem.xml.j2' %}
+{% from 'macros.j2' import dem_pixel_spacing %}
+{% block dataIdInfo %}
+    <dataIdInfo>
+        <idPurp>This file is the DEM used in the radiometric terrain correction process (using GAMMA software) for a granule of {{ granule_type }} SAR data from the Sentinel-1 mission. Cell values indicate the elevation in meters, and have been resampled to a pixel spacing of {{ pixel_spacing|int }} m. To access actual {{ scale }} values, refer to the VV/VH/HV/HH TIFF files included in the same folder as this image.</idPurp>
+        <idAbs>&lt;DIV STYLE="text-align:Left;"&gt;&lt;DIV&gt;&lt;DIV&gt;&lt;P&gt;&lt;SPAN&gt;This is the digital elevation model used in the radiometric terrain correction process for a granule of {{ granule_description }} ({{ granule_type }}) Synthetic Aperture Radar data from the Copernicus Sentinel-1 mission (European Space Agency). The granule was processed by ASF DAAC HyP3 {{ processing_date.year }} using the {{ plugin_name }} plugin version {{ plugin_version }} running {{ processor_name }} release {{ processor_version }}, and the extent of the DEM is clipped to the size needed for full granule coverage, or to the extent of the available DEM data if full coverage is not available. The DEM was reprojected to {{ projection }}, and the pixel spacing was resampled from the native DEM pixel spacing to {{ pixel_spacing|int }} m.&lt;/SPAN&gt;&lt;/P&gt;&lt;P&gt;&lt;SPAN&gt;The best DEM publicly available for each granule is used in the RTC process, so different granules may be processed using different source DEM layers. This granule used {{ dem_name }} as the source DEM: the Copernicus DEM GLO-30, which has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}.&lt;/SPAN&gt;&lt;/P&gt;&lt;P&gt;&lt;SPAN&gt;The Copernicus DEM GLO-30 is a global Digital Surface Model (DSM) at 30-m pixel spacing derived from the WorldDEM. The WorldDEM is based on radar satellite data acquired by the TanDEM-X mission, which was funded by the German Aerospace Center (DLR) and Airbus Defence and Space, and edited to flatten water bodies, provide consistent flow of rivers, and apply corrections to shore/coastlines and special features. For more information, refer to &lt;/SPAN&gt;&lt;A href="https://spacedata.copernicus.eu/documents/20126/0/GEO1988-CopernicusDEM-SPE-002_ProductHandbook_I1.00.pdf"&gt;&lt;SPAN&gt;https://spacedata.copernicus.eu/documents/20126/0/GEO1988-CopernicusDEM-SPE-002_ProductHandbook_I1.00.pdf&lt;/SPAN&gt;&lt;/A&gt;&lt;SPAN&gt;.&lt;/SPAN&gt;&lt;/P&gt;&lt;P&gt;&lt;SPAN&gt;The actual {{ scale }} data is contained in the VV/HH (primary polarization) and/or VH/HV (cross-polarization) TIFF files included in the same downloaded folder as this file. The name of the SAR granule used to generate the files in this folder is: {{ granule_name }}. For a detailed description of the Sentinel-1 file naming convention, refer to &lt;/SPAN&gt;&lt;A href="https://asf.alaska.edu/data-sets/sar-data-sets/sentinel-1/sentinel-1-data-and-imagery/#Naming_Convention"&gt;&lt;SPAN&gt;https://asf.alaska.edu/data-sets/sar-data-sets/sentinel-1/sentinel-1-data-and-imagery/#Naming_Convention&lt;/SPAN&gt;&lt;/A&gt;&lt;SPAN&gt;.&lt;/SPAN&gt;&lt;/P&gt;&lt;P&gt;&lt;SPAN&gt;For areas where there is not a publicly-available digital elevation model (i.e. sea ice), geocoded products without terrain correction are also available from &lt;/SPAN&gt;&lt;A href="http://hyp3.asf.alaska.edu"&gt;&lt;SPAN&gt;http://hyp3.asf.alaska.edu&lt;/SPAN&gt;&lt;/A&gt;&lt;SPAN&gt;.&lt;/SPAN&gt;&lt;/P&gt;&lt;P&gt;&lt;SPAN&gt;The Sentinel-1A satellite was launched April 3, 2014, and the Sentinel-1B satellite was launched April 25, 2016. The satellites each have a 12-day repeat cycle. More information about the mission is available at &lt;/SPAN&gt;&lt;A href="https://earth.esa.int/web/guest/missions/esa-operational-eo-missions/sentinel-1"&gt;&lt;SPAN&gt;https://earth.esa.int/web/guest/missions/esa-operational-eo-missions/sentinel-1&lt;/SPAN&gt;&lt;/A&gt;&lt;SPAN&gt;.&lt;/SPAN&gt;&lt;/P&gt;&lt;P&gt;&lt;SPAN&gt;Additional information about Sentinel-1 data, imagery, tools and applications is available at &lt;/SPAN&gt;&lt;A href="https://asf.alaska.edu/data-sets/sar-data-sets/sentinel-1/"&gt;&lt;SPAN&gt;https://asf.alaska.edu/data-sets/sar-data-sets/sentinel-1&lt;/SPAN&gt;&lt;/A&gt;&lt;SPAN&gt;.&lt;/SPAN&gt;&lt;/P&gt;&lt;/DIV&gt;&lt;/DIV&gt;&lt;/DIV&gt;
+        </idAbs>
+        <idCredit>Source DEM Data: These data are distributed by ENTER DISTRIBUTION ENTITY AND EMAIL/WEBSITE</idCredit>
+        <idCitation xmlns="">
+            <date>
+                <pubDate>{{ processing_date.isoformat(timespec='seconds') }}</pubDate>
+            </date>
+            <citRespParty xmlns="">
+                <rpOrgName>Alaska Satellite Facility</rpOrgName>
+                <role>
+                    <RoleCd value="007"/>
+                </role>
+                <rpCntInfo xmlns="">
+                    <cntAddress addressType="physical">
+                        <delPoint>2156 Koyukuk Dr.</delPoint>
+                        <city>Fairbanks</city>
+                        <adminArea>Alaska</adminArea>
+                        <postCode>99775-7320</postCode>
+                        <eMailAdd>uso@asf.alaska.edu</eMailAdd>
+                        <country>US</country>
+                    </cntAddress>
+                    <cntPhone>
+                        <voiceNum tddtty="">907-474-5041</voiceNum>
+                    </cntPhone>
+                </rpCntInfo>
+            </citRespParty>
+        </idCitation>
+        <searchKeys>
+            <keyword>Alaska Satellite Facility</keyword>
+            <keyword>ASF</keyword>
+            <keyword>Synthetic Aperture Radar</keyword>
+            <keyword>SAR</keyword>
+            <keyword>Radiometric Terrain Correction</keyword>
+            <keyword>RTC</keyword>
+            <keyword>Digital Elevation Model</keyword>
+            <keyword>DEM</keyword>
+            <keyword>Sentinel-1</keyword>
+        </searchKeys>
+        <dataLang>
+            <languageCode value="eng"/>
+            <countryCode value="US"/>
+        </dataLang>
+        <dataChar>
+            <CharSetCd value="004"/>
+        </dataChar>
+        <idPoC xmlns="">
+            <rpOrgName>ENTER COPERNICUS SOURCE INFO</rpOrgName>
+            <role>
+                <RoleCd value="006"/>
+            </role>
+            <rpCntInfo xmlns="">
+                <cntAddress addressType="physical">
+                    <delPoint>ENTER STREET ADDRESS</delPoint>
+                    <city>ENTER CITY</city>
+                    <adminArea>ENTER STATE/PROVINCE</adminArea>
+                    <postCode>ENTER POSTAL CODE</postCode>
+                    <country>ENTER COUNTRY</country>
+                    <eMailAdd>ENTER EMAIL</eMailAdd>
+                </cntAddress>
+                <cntPhone>
+                    <voiceNum tddtty="">ENTER PHONE NUMBER</voiceNum>
+                </cntPhone>
+            </rpCntInfo>
+            <displayName>Alaska Satellite Facility</displayName>
+        </idPoC>
+        <resMaint xmlns="">
+            <maintFreq>
+                <MaintFreqCd value="009"/>
+            </maintFreq>
+        </resMaint>
+        <resConst>
+            <Consts xmlns="">
+                <useLimit>&lt;DIV STYLE="text-align:Left;"&gt;&lt;DIV&gt;&lt;DIV&gt;&lt;P&gt;&lt;SPAN&gt;ENTER USE OR RESTRICTION INFO&lt;/SPAN&gt;&lt;/P&gt;&lt;/DIV&gt;&lt;/DIV&gt;&lt;/DIV&gt;</useLimit>
+            </Consts>
+        </resConst>
+        <envirDesc>This product was generated by ASF DAAC HyP3 {{ processing_date.year }} using the {{ plugin_name }} plugin version {{ plugin_version }} running {{ processor_name }} release {{ processor_version }}.</envirDesc>
+        <tpCat>
+            <TopicCatCd value="006"/>
+        </tpCat>
+    </dataIdInfo>
+{% endblock %}
+{% block dataLineage %}
+        <dataLineage>
+            <statement>The digital elevation model was converted from ENTER FORMAT INFO files into GeoTIFFs. During this reformatting process, a geoid correction to WGS84 was applied. At the start of terrain correction, the best DEM covering the SAR image is selected, converted into UTM coordinates, and used for processing.</statement>
+        </dataLineage>
+{% endblock %}

--- a/hyp3_metadata/macros.j2
+++ b/hyp3_metadata/macros.j2
@@ -18,7 +18,7 @@
     {%- elif dem_name == 'SRTMGL3' -%}
         3 arc seconds (about 90 meters)
     {%- elif dem_name == 'COP30' -%}
-        30 meters
+        1 arc second (about 30 meters)
     {%- else -%}
         UNKNOWN
     {%- endif %}

--- a/hyp3_metadata/macros.j2
+++ b/hyp3_metadata/macros.j2
@@ -17,6 +17,8 @@
         1 arc second (about 30 meters)
     {%- elif dem_name == 'SRTMGL3' -%}
         3 arc seconds (about 90 meters)
+    {%- elif dem_name == 'COP30' -%}
+        30 meters
     {%- else -%}
         UNKNOWN
     {%- endif %}
@@ -34,5 +36,7 @@
         The REMA DEM was constructed from hundreds of thousands of individual stereoscopic Digital Elevation Models extracted from pairs of submeter-resolution DigitalGlobe satellite imagery acquired between 2009 and 2017, and vertically registered to altimetry measurements from Cryosat-2 and ICESat. For more information and to access the full REMA dataset at the original 8-meter resolution, refer to https://www.pgc.umn.edu/data/rema/.
     {%- elif dem_name.startswith('SRTM') -%}
         The SRTM was flown aboard the space shuttle Endeavour February 11-22, 2000. The National Aeronautics and Space Administration (NASA) and the National Geospatial-Intelligence Agency (NGA) participated in an international project to acquire radar data which were used to create the first near-global set of land elevations. For more information and to access the full SRTM dataset, refer to https://www.usgs.gov/centers/eros/science/usgs-eros-archive-digital-elevation-shuttle-radar-topography-mission-srtm-1-arc?qt-science_center_objects=0#qt-science_center_objects.
+    {%- elif dem_name.startswith('COP30') -%}
+        The GLO-30 Copernicus DEM is a global Digital Surface Model (DSM) at 30-m pixel spacing derived from the WorldDEM. The WorldDEM is based on radar satellite data acquired by the TanDEM-X mission, which was funded by the German Aerospace Center (DLR) and Airbus Defence and Space, and edited to flatten water bodies, provide consistent flow of rivers, and apply corrections to shore/coastlines and special features. For more information, refer to https://spacedata.copernicus.eu/documents/20126/0/GEO1988-CopernicusDEM-SPE-002_ProductHandbook_I1.00.pdf.
     {%- endif %}
 {% endmacro %}

--- a/hyp3_metadata/readme.md.txt.j2
+++ b/hyp3_metadata/readme.md.txt.j2
@@ -90,7 +90,9 @@ KMZ files are generated for use in Google Earth and other compatible application
 
 The Digital Elevation Model (DEM) layer is included with standard products, but is optional when placing a custom order for imagery. This layer is tagged with _dem.tif, and is provided in 16-bit signed integer format. Note that the actual RTC correction is performed using a 32-bit float version, but this file has been converted to 16-bit to reduce file size.
 
-The DEM used for this product is {{ dem_name }}, which has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }} The source DEM has a geoid correction applied before it is used for RTC, so values in this file will differ from the source DEM. It is provided in the same pixel spacing/alignment as the RTC product.
+The source DEM has a geoid correction applied before it is used for RTC, so elevation values in this file will differ from the source DEM. It is provided in the same pixel spacing/alignment as the RTC product.
+
+The DEM used for this product is {{ dem_name }}, which has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }}
 
 {% if dem_blurb(dem_name) %}
 *Refer to the _dem.tif.xml file for additional information about the specific DEM included with this product, including use and citation requirements.*

--- a/hyp3_metadata/readme.md.txt.j2
+++ b/hyp3_metadata/readme.md.txt.j2
@@ -88,9 +88,9 @@ KMZ files are generated for use in Google Earth and other compatible application
 -------------
 ## 3. DEM used to correct the data
 
-The Digital Elevation Model (DEM) layer is included with standard products, but is optional when placing a custom order for imagery. This layer is tagged with _dem.tif
+The Digital Elevation Model (DEM) layer is included with standard products, but is optional when placing a custom order for imagery. This layer is tagged with _dem.tif, and is provided in 16-bit integer format. Note that the actual RTC correction is done using a 32-bit float version, but this file is converted back to 16-bit to reduce the file size.
 
-The DEM used for this product is {{ dem_name }}, which has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }}
+The DEM used for this product is {{ dem_name }}, which has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }} The source DEM has a geoid correction applied before it is used for RTC, so values in this file will differ from the source DEM. It is provided in the same pixel spacing/alignment as the RTC product.
 
 {% if dem_blurb(dem_name) %}
 *Refer to the _dem.tif.xml file for additional information about the specific DEM included with this product, including use and citation requirements.*

--- a/hyp3_metadata/readme.md.txt.j2
+++ b/hyp3_metadata/readme.md.txt.j2
@@ -88,7 +88,7 @@ KMZ files are generated for use in Google Earth and other compatible application
 -------------
 ## 3. DEM used to correct the data
 
-The Digital Elevation Model (DEM) layer is included with standard products, but is optional when placing a custom order for imagery. This layer is tagged with _dem.tif, and is provided in 16-bit integer format. Note that the actual RTC correction is done using a 32-bit float version, but this file is converted back to 16-bit to reduce the file size.
+The Digital Elevation Model (DEM) layer is included with standard products, but is optional when placing a custom order for imagery. This layer is tagged with _dem.tif, and is provided in 16-bit signed integer format. Note that the actual RTC correction is performed using a 32-bit float version, but this file has been converted to 16-bit to reduce file size.
 
 The DEM used for this product is {{ dem_name }}, which has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }} The source DEM has a geoid correction applied before it is used for RTC, so values in this file will differ from the source DEM. It is provided in the same pixel spacing/alignment as the RTC product.
 


### PR DESCRIPTION
This PR updates the metadata files to accommodate RTC products using the Copernicus DEM.

- Readme
- DEM blurb macros
- COP-30 XML file

Changes are also made to the language describing the DEMs to reference the format, and describe differences between the source DEMs, the versions used by GAMMA (in 32-bit float), and the versions included in the package (16-bit signed integer).