### PR TITLE
update copernicus name to GLO-30

### DIFF
--- a/hyp3_metadata/__main__.py
+++ b/hyp3_metadata/__main__.py
@@ -6,7 +6,7 @@ from dateutil.parser import parse as dt_parse
 from hyp3_metadata import __version__, create_metadata_file_set
 from hyp3_metadata.util import populate_example_data
 
-_SUPPORTED_DEMS = ['EU_DEM_V11', 'GIMP', 'IFSAR', 'NED13', 'NED1', 'NED2', 'REMA', 'SRTMGL1', 'SRTMGL3', 'COP30']
+_SUPPORTED_DEMS = ['EU_DEM_V11', 'GIMP', 'IFSAR', 'NED13', 'NED1', 'NED2', 'REMA', 'SRTMGL1', 'SRTMGL3', 'GLO-30']
 
 
 def main():
@@ -21,7 +21,7 @@ def main():
     parser.add_argument('--granule-name',
                         default='S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8',
                         help='Source granule used to generate the RTC product')
-    parser.add_argument('--dem-name', default='COP30', choices=_SUPPORTED_DEMS,
+    parser.add_argument('--dem-name', default='GLO-30', choices=_SUPPORTED_DEMS,
                         help='DEM used to generate the RTC product')
     parser.add_argument('--processing-date', default='2020-01-01T00:00:00+00:00', type=dt_parse)
     parser.add_argument('--looks', default=1, type=int,

--- a/hyp3_metadata/templates/macros.j2
+++ b/hyp3_metadata/templates/macros.j2
@@ -17,7 +17,7 @@
         1 arc second (about 30 meters)
     {%- elif dem_name == 'SRTMGL3' -%}
         3 arc seconds (about 90 meters)
-    {%- elif dem_name == 'COP30' -%}
+    {%- elif dem_name == 'GLO-30' -%}
         1 arc second (about 30 meters)
     {%- else -%}
         UNKNOWN
@@ -36,7 +36,7 @@
         The REMA DEM was constructed from hundreds of thousands of individual stereoscopic Digital Elevation Models extracted from pairs of submeter-resolution DigitalGlobe satellite imagery acquired between 2009 and 2017, and vertically registered to altimetry measurements from Cryosat-2 and ICESat. For more information and to access the full REMA dataset at the original 8-meter resolution, refer to https://www.pgc.umn.edu/data/rema/.
     {%- elif dem_name.startswith('SRTM') -%}
         The SRTM was flown aboard the space shuttle Endeavour February 11-22, 2000. The National Aeronautics and Space Administration (NASA) and the National Geospatial-Intelligence Agency (NGA) participated in an international project to acquire radar data which were used to create the first near-global set of land elevations. For more information and to access the full SRTM dataset, refer to https://www.usgs.gov/centers/eros/science/usgs-eros-archive-digital-elevation-shuttle-radar-topography-mission-srtm-1-arc?qt-science_center_objects=0#qt-science_center_objects.
-    {%- elif dem_name.startswith('COP') -%}
+    {%- elif dem_name == 'GLO-30' -%}
         The Copernicus DEM is a global Digital Surface Model (DSM) derived from the WorldDEM. The WorldDEM is based on radar satellite data acquired by the TanDEM-X mission, which was funded by the German Aerospace Center (DLR) and Airbus Defence and Space, and edited to flatten water bodies, provide consistent flow of rivers, and apply corrections to shore/coastlines and special features. For more information, refer to https://spacedata.copernicus.eu/documents/20126/0/GEO1988-CopernicusDEM-SPE-002_ProductHandbook_I1.00.pdf.
     {%- endif %}
 {% endmacro %}


### PR DESCRIPTION
This label appears to the user in four places:

* README (where it's immediately followed by the full `Copernicus DEM GLO-30` name)
* backscatter xml
* greyscale browse xml
* color browse xml