### PR TITLE
drop ALLOW_TAG_PREFIX option deprecated in git-release v4.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         uses: docker://antonyurchenko/git-release:latest
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
-          ALLOW_TAG_PREFIX: "true"
           RELEASE_NAME_PREFIX: "HyP3 Metadata Templates "
 
       - name: Attempt fast-forward develop from main


### PR DESCRIPTION
Release notes: https://github.com/anton-yurchenko/git-release/releases

Failed run: https://github.com/ASFHyP3/hyp3-metadata-templates/runs/2842567440?check_suite_focus=true

Release notes *suggest* we can just drop the line, but I haven't verified that yet.