### PR TITLE
generate water mask xml for insar products

### DIFF
--- a/hyp3_metadata/insar.py
+++ b/hyp3_metadata/insar.py
@@ -32,6 +32,7 @@ class InSarMetadataWriter:
             self.create_vertical_displacement_xml,
             self.create_wrapped_phase_xml,
             self.create_inc_map_xml,
+            self.create_water_mask_xml,
         ]
         for generator in generators:
             output = generator()
@@ -98,6 +99,10 @@ class InSarMetadataWriter:
     def create_inc_map_xml(self) -> Path:
         reference_file = self.product_dir / f'{self.product_name}_inc_map.tif'
         return self.create_metadata_file(self.payload, 'insar/inc_map_tif.xml.j2', reference_file)
+
+    def create_water_mask_xml(self) -> Path:
+        reference_file = self.product_dir / f'{self.product_name}_water_mask.tif'
+        return self.create_metadata_file(self.payload, 'insar/water_mask_tif.xml.j2', reference_file)
 
     @classmethod
     def create_metadata_file(cls, payload: dict, template: str, reference_file: Path, out_ext: str = 'xml',

--- a/tests/test_insar_gamma.py
+++ b/tests/test_insar_gamma.py
@@ -231,6 +231,26 @@ def test_inc_map_xml(insar_product_dir):
     assert output_file.exists()
 
 
+def test_water_mask_xml(insar_product_dir):
+    payload = hyp3_metadata.insar.marshal_metadata(
+        product_dir=insar_product_dir,
+        reference_granule_name='S1B_IW_SLC__1SSH_20210430T125122_20210430T125149_026696_033052_6408',
+        secondary_granule_name='S1A_IW_SLC__1SSH_20210424T125204_20210424T125231_037592_046F17_3392',
+        processing_date=datetime.strptime('2020-01-01T00:00:00+0000', '%Y-%m-%dT%H:%M:%S%z'),
+        looks='20x4',
+        dem_name='GLO-30',
+        plugin_name='hyp3_insar_gamma',
+        plugin_version='2.3.0',
+        processor_name='GAMMA',
+        processor_version='20191203',
+    )
+    writer = insar.InSarMetadataWriter(payload)
+    output_file = writer.create_water_mask_xml()
+    assert output_file == insar_product_dir / \
+           'S1AB_20210424T125204_20210430T125122_HHP006_INT80_G_ueF_B4A1_water_mask.tif.xml'
+    assert output_file.exists()
+
+
 def test_insar_gamma_all_files(insar_product_dir):
     files = create_metadata_file_set_insar(
         product_dir=insar_product_dir,
@@ -258,6 +278,7 @@ def test_insar_gamma_all_files(insar_product_dir):
         insar_product_dir / 'S1AB_20210424T125204_20210430T125122_HHP006_INT80_G_ueF_B4A1_vert_disp.tif.xml',
         insar_product_dir / 'S1AB_20210424T125204_20210430T125122_HHP006_INT80_G_ueF_B4A1_wrapped_phase.tif.xml',
         insar_product_dir / 'S1AB_20210424T125204_20210430T125122_HHP006_INT80_G_ueF_B4A1_inc_map.tif.xml',
+        insar_product_dir / 'S1AB_20210424T125204_20210430T125122_HHP006_INT80_G_ueF_B4A1_water_mask.tif.xml',
     ]
     for f in files:
         assert f.exists()


### PR DESCRIPTION
Tests pass when I copy `insar_inc_map.tif` to `insar_water_mask.tif` in the test data directory, but I'm generating an InSAR product now and will pull in a more representative water_mask geotiff.  I also still need to test the sample-generation script.