### PR TITLE
add .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners will be requested for review when someone opens a pull request.
+*       @ASFHyP3/documentation


### PR DESCRIPTION
Will cause GitHub to auto-assign the Documentation group to review pull requests.