### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # HyP3 Metadata Templates
 
+--- 
+## NOTICE: This repository is archived!
+
+We've archived this repository and merged it into the [hyp3-gamma](https://github.com/ASFHyP3/hyp3-gamma)
+plugin. Currently, only the hyp3-gamma plugin is leveraging this package and updating
+metadata GAMMA based products is needlessly slowed down. If and when we have non-GAMMA
+based plugins that could leverage this package, we *may* revive this package, or a core
+subset therein. 
+
+---
+
 Package for generating HyP3 products' metadata.
 
 The goal is for each process to have a README text file, which gives an overview


### PR DESCRIPTION
This repository/package is being migrated into the HyP3 GAMMA plugin (see ASFHyP3/hyp3-gamma#307) and archived until we actually have more than one HyP3 plugin which can leverage it. 

We should provide a notice in the README, and then archive this repo. 